### PR TITLE
CMakeLists: Fix pico generate pio header path

### DIFF
--- a/40col-color/CMakeLists.txt
+++ b/40col-color/CMakeLists.txt
@@ -90,8 +90,8 @@ list( APPEND to_build picoterm picoterm_US picoterm_DE picoterm_FR picoterm_BE )
 # Common definition for all the executables
 foreach( exec ${to_build} )
   add_executable( ${exec} ${sources} )
-	pico_generate_pio_header( ${exec} ../../common/uart_tx.pio)
-	pico_generate_pio_header( ${exec} ../../common/spi.pio)
+	pico_generate_pio_header( ${exec} ${CMAKE_CURRENT_SOURCE_DIR}/../common/uart_tx.pio)
+	pico_generate_pio_header( ${exec} ${CMAKE_CURRENT_SOURCE_DIR}/../common/spi.pio)
 	pico_enable_stdio_usb( ${exec} 0)  # Redirect printf to USB-Serial. Conflict with TinyUSB!
 	pico_enable_stdio_uart( ${exec} 0) # Redirect printf to uart0. But no room to place UART0 on GPIO!
 

--- a/80col-mono/CMakeLists.txt
+++ b/80col-mono/CMakeLists.txt
@@ -94,8 +94,8 @@ list( APPEND to_build_list picoterm picoterm_US picoterm_DE picoterm_FR picoterm
 # Common definition for all the executables
 foreach( exec ${to_build_list} )
   add_executable( ${exec} ${sources} )
-	pico_generate_pio_header( ${exec} ../../common/uart_tx.pio)
-	pico_generate_pio_header( ${exec} ../../common/spi.pio)
+	pico_generate_pio_header( ${exec} ${CMAKE_CURRENT_SOURCE_DIR}/../common/uart_tx.pio)
+	pico_generate_pio_header( ${exec} ${CMAKE_CURRENT_SOURCE_DIR}/../common/spi.pio)
 	pico_enable_stdio_usb( ${exec} 0 ) # Redirect printf to USB-Serial. Conflict with TinyUSB!
 	pico_enable_stdio_uart( ${exec} 0) # Redirect printf to uart0. But no room to place UART0 on GPIO!
 


### PR DESCRIPTION
On my builds, I was receiving the following compiler error:

Scanning dependencies of target picoterm_uart_tx_pio_h make[3]: *** No rule to make target '../../../common/uart_tx.pio', needed by 'uart_tx.pio.h'. Stop. make[2]: *** [CMakeFiles/Makefile2:2316: CMakeFiles/picoterm_uart_tx_pio_h.dir/all] Error 2 make[1]: *** [CMakeFiles/Makefile2:2559: CMakeFiles/picoterm.dir/rule] Error 2

I fix this by giving pico_generate_pio_header() an absolute path from CMAKE_CURRENT_SOURCE_DIR rather that a relative path in the CMakeLists.txt.