### PR TITLE
issue #45: Fix traditional background colour sequence

### DIFF
--- a/40col-color/picoterm_core.c
+++ b/40col-color/picoterm_core.c
@@ -319,13 +319,13 @@ void esc_sequence_received(){
                 foreground_colour = palette[esc_parameters[0]-30];
             }
             if(esc_parameters[0]>=40 && esc_parameters[0]<=47){
-                foreground_colour = palette[esc_parameters[0]-40];
+                background_colour = palette[esc_parameters[0]-40];
             }
             if(esc_parameters[0]>=90 && esc_parameters[0]<=97){
                 foreground_colour = palette[esc_parameters[0]-82]; // 90 is palette[8]
             }
             if(esc_parameters[0]>=100 && esc_parameters[0]<=107){
-                foreground_colour = palette[esc_parameters[0]-92];  // 100 is palette[8]
+                background_colour = palette[esc_parameters[0]-92];  // 100 is palette[8]
             }
 
             //case 38:


### PR DESCRIPTION
There is an error in the colouring for the ANSI/VT100 sequences for ESC [40m to [47m that incorrectly sets foreground colour. These should set the background colour.

The same issue applies for ESC [100m to ESC [107m for bright background.

This patch fixes the support for the traditional 8 colour (plus 8 bright colour) support.